### PR TITLE
Fix: Remove unused anyhow dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 pandas>=1.0.0
 ta>=0.7.0
 pybit>=2.4.0
-anyhow>=0.0.1
-


### PR DESCRIPTION
The `anyhow` package was listed in `requirements.txt` but was not imported or used in your codebase. This caused errors in the CI/CD pipeline as the package could not be found on PyPI.

This commit removes `anyhow>=0.0.1` from `requirements.txt` to resolve the dependency installation issue.